### PR TITLE
do not lint binstubs

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -1032,6 +1032,7 @@ step 'Add guard-rspec gem' do
   install_gem 'guard-rspec', group: :ct
   run_command 'guard init rspec'
   gsub_file 'Guardfile', /  # Capybara features specs.*\z/m, "end\n"
+  run_command 'bundle binstubs guard'
 end
 
 rubocop_guardfile = <<'EOS'


### PR DESCRIPTION
binstubs generated by bundler do not lint, and should be excluded by default from rubocop runs.

``` bash
$ bunde binstubs guard
```
