### PR TITLE
Fix chef-solo recipies so we can vagrant up on i

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -350,6 +350,7 @@ chef_node_json = <<-EOS
   },
 
   "rbenv": {
+    "git_url": "https://github.com/sstephenson/rbenv.git",
     "user_installs": [
       {
         "user": "vagrant",
@@ -368,7 +369,7 @@ chef_node_json = <<-EOS
 
   "nodejs": {
     "version": "0.10.15",
-    "install_method": "package"
+    "install_method": "binary"
   },
 
   "run_list": [


### PR DESCRIPTION
Two things were preventing vagrant from provisioning on 'i':
- Using git protocol when downloading rbenv repo
- Trying to access keyserver.ubuntu.com when installing Node.js from a package

We now use https for rbenv repo and install node from binary, so
you can successfully complete vagrant provisioning even on i.

Total time for new VM build: 11 min 15 s
