### PR TITLE
remove-email-preview

### DIFF
--- a/recipes/email_init.rb
+++ b/recipes/email_init.rb
@@ -1,7 +1,5 @@
-gem 'email_preview', group: :development
 gem 'mailcatcher', group: :toolbox
 
-get_file 'config/initializers/email_preview.rb'
 get_file 'config/initializers/add_appname_to_email_subject.rb'
 
 append_to_file '.env', get_file_partial(:email, '.env')

--- a/template.rb
+++ b/template.rb
@@ -799,10 +799,8 @@ say_recipe 'email_init'
 @configs[@current_recipe] = config
 # >-------------------------- recipes/email_init.rb --------------------------start<
 
-gem 'email_preview', group: :development
 gem 'mailcatcher', group: :toolbox
 
-get_file 'config/initializers/email_preview.rb'
 get_file 'config/initializers/add_appname_to_email_subject.rb'
 
 append_to_file '.env', get_file_partial(:email, '.env')


### PR DESCRIPTION
### Changelog
- remove email_preview gem
  Use Rails 4.1 ActionMailer Previews as preferred pattern instead.
