### PR TITLE
layout-header

### DIFF
--- a/files/app/views/layouts/_header.html.erb
+++ b/files/app/views/layouts/_header.html.erb
@@ -12,7 +12,7 @@
     </div>
     <div class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
-        <%= render 'layouts/navigation_links' %>
+        <%# navigation links go here %>
       </ul>
     </div>
   </div>

--- a/files/app/views/layouts/_navigation_links.html.erb
+++ b/files/app/views/layouts/_navigation_links.html.erb
@@ -1,1 +1,0 @@
-<%# add navigation links to this file %>

--- a/files/app/views/layouts/application.html.erb
+++ b/files/app/views/layouts/application.html.erb
@@ -10,6 +10,11 @@
     <%= csrf_meta_tags %>
   </head>
   <body>
+    <%- if content_for?(:header) %>
+      <%= yield :header %>
+    <%- else %>
+      <%= render 'layouts/header' %>
+    <%- end %>
     <%= render 'layouts/messages' %>
     <%= yield %>
 

--- a/files/app/views/pages/home.html.haml
+++ b/files/app/views/pages/home.html.haml
@@ -1,3 +1,5 @@
+- content_for :header do
+  .noheader
 .section#hero
   .container
     .row

--- a/recipes/webapp.rb
+++ b/recipes/webapp.rb
@@ -40,8 +40,7 @@ get_file 'app/assets/stylesheets/reset.css.scss', eval: false
 get_file 'app/views/layouts/_analytics.html.erb'
 get_file 'app/views/layouts/_footer.html.haml', eval: false
 get_file 'app/views/layouts/_messages.html.erb', eval: false
-get_file 'app/views/layouts/_navigation.html.erb', eval: false
-get_file 'app/views/layouts/_navigation_links.html.erb', eval: false
+get_file 'app/views/layouts/_header.html.erb', eval: false
 get_file 'app/views/layouts/application.html.erb', eval: false
 
 get_file 'app/views/pages/home.html.haml', eval: false


### PR DESCRIPTION
Add default header to layout for public pages.

Fixes #43

Screenshot of default header:
https://www.evernote.com/shard/s7/sh/148ba858-145f-4c0d-993a-e43d873ebd69/ac21b6dccde021406bb06e63a617ff15

Changes:
- Add content_for :header to configure custom header per page
- Update home page to "opt-out" of default header rendering
- combine _navigation and _navigation_links partials into _header

<!---
@huboard:{"order":58.0,"milestone_order":58,"custom_state":""}
-->
